### PR TITLE
HDD-1443 export ready document with indents

### DIFF
--- a/lib/rtf.js
+++ b/lib/rtf.js
@@ -38,22 +38,10 @@ module.exports = RTF = function () {
 
 RTF.prototype.writeText = function (text, format, groupName) {
     element = new TextElement(text, format);
-
-    console.debug("rtf - adding text ("+ text + ") to group: " + groupName);
-
-    if (groupName !== undefined) {
-      var groupIndex = this._groupIndex(groupName);
-      console.debug("groupindex: " + groupIndex);
-
-      if (groupIndex >= 0) {
-        this.elements[this._groupIndex(groupName)].addElement(element);
-        console.debug("groupName: " + groupName);
+    if(groupName !== undefined && this._groupIndex(groupName) >= 0) {
+      this.elements[this._groupIndex(groupName)].addElement(element);
       } else {        
-        console.debug("group ("+groupName+") not found");
-      }
-    } else {
       this.elements.push(element);
-      console.debug("adding element without group");
     }
 };
 
@@ -63,13 +51,9 @@ RTF.prototype.addTable = function (table) {
 };
 
 RTF.prototype.addTextGroup = function (name, format) {
-  console.debug("rtf - adding group element " + name);
-
   if(this._groupIndex(name)<0) {//make sure we don't have duplicate groups!
     formatGroup = new GroupElement(name, format);
     this.elements.push(formatGroup);
-
-    console.debug("rtf - added format group element " + name);
   }
 };
 
@@ -112,14 +96,10 @@ var index = -1;
 
   this.elements.forEach(function(el, i) {
     if(el instanceof GroupElement && el.name===name) {
-      console.debug("found group " + name + " at index " + i);
       index = i;
     }
-    else {
-      //console.debug(`el ${typeof el} ${el.name} !== ${name} ${i}`);
-    }
   });
-  
+
   return index;
 };
 

--- a/lib/rtf.js
+++ b/lib/rtf.js
@@ -38,10 +38,22 @@ module.exports = RTF = function () {
 
 RTF.prototype.writeText = function (text, format, groupName) {
     element = new TextElement(text, format);
-    if(groupName !== undefined && this._groupIndex(groupName) >= 0) {
-      this.elements[this._groupIndex(groupName)].push(element);
+
+    console.debug("rtf - adding text ("+ text + ") to group: " + groupName);
+
+    if (groupName !== undefined) {
+      var groupIndex = this._groupIndex(groupName);
+      console.debug("groupindex: " + groupIndex);
+
+      if (groupIndex >= 0) {
+        this.elements[this._groupIndex(groupName)].addElement(element);
+        console.debug("groupName: " + groupName);
+      } else {        
+        console.debug("group ("+groupName+") not found");
+      }
     } else {
       this.elements.push(element);
+      console.debug("adding element without group");
     }
 };
 
@@ -51,9 +63,13 @@ RTF.prototype.addTable = function (table) {
 };
 
 RTF.prototype.addTextGroup = function (name, format) {
+  console.debug("rtf - adding group element " + name);
+
   if(this._groupIndex(name)<0) {//make sure we don't have duplicate groups!
     formatGroup = new GroupElement(name, format);
     this.elements.push(formatGroup);
+
+    console.debug("rtf - added format group element " + name);
   }
 };
 
@@ -92,12 +108,19 @@ RTF.prototype.addPar = function (groupName) {
 //gets the index of a group
 //TODO: make this more private by removing it from prototype and passing elements
 RTF.prototype._groupIndex = function (name) {
-  this.elements.forEach(function(el, i){
+var index = -1;
+
+  this.elements.forEach(function(el, i) {
     if(el instanceof GroupElement && el.name===name) {
-      return i;
+      console.debug("found group " + name + " at index " + i);
+      index = i;
+    }
+    else {
+      //console.debug(`el ${typeof el} ${el.name} !== ${name} ${i}`);
     }
   });
-  return -1;
+  
+  return index;
 };
 
  RTF.prototype.createDocument = function (callback) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 { 
   "name" : "@happy-doc/rtf",
-  "version" : "0.0.1",
+  "version" : "0.0.2",
   "description" : "Assists with creating rich text documents.",
   "main" : "./lib/rtf.js",
   "author" : "HappyDoc",


### PR DESCRIPTION
clearly never worked
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix `writeText` function in `lib/rtf.js` to handle group elements correctly and update version in `package.json`.
> 
>   - **Behavior**:
>     - Fix `writeText()` in `lib/rtf.js` to use `addElement()` instead of `push()` for group elements.
>     - Correct `_groupIndex()` in `lib/rtf.js` to return the correct index of a group.
>   - **Versioning**:
>     - Update version in `package.json` from `0.0.1` to `0.0.2`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=happy-doc%2Fnode-rtf&utm_source=github&utm_medium=referral)<sup> for 72958a60e908ca788c2f2c3079af8d7ce4fec291. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->