### PR TITLE
Hdd-1443 export ready fields with indents

### DIFF
--- a/lib/format.js
+++ b/lib/format.js
@@ -93,6 +93,8 @@ Format.prototype.formatText = function(text, colorTable, fontTable, safeText){
     if(this.rightIndent>0) rtf += "\\ri" + this.rightIndent.toString();
 
     //we don't escape text if there are other elements in it, so set a flag
+    //ensure that there is a space between the control character and the text
+    //otherwise things won't render properly
     var content = " ";
     if(safeText === undefined || safeText){
       content += Utils.getRTFSafeText(text);

--- a/lib/format.js
+++ b/lib/format.js
@@ -93,7 +93,7 @@ Format.prototype.formatText = function(text, colorTable, fontTable, safeText){
     if(this.rightIndent>0) rtf += "\\ri" + this.rightIndent.toString();
 
     //we don't escape text if there are other elements in it, so set a flag
-    var content = "";
+    var content = " ";
     if(safeText === undefined || safeText){
       content += Utils.getRTFSafeText(text);
     }else{
@@ -112,7 +112,7 @@ Format.prototype.formatText = function(text, colorTable, fontTable, safeText){
     if(this.makeParagraph) rtf += "\\par";
 
     //close doc
-    rtf+="}";
+    rtf+="}\n";
 
     return rtf;
 };

--- a/lib/format.js
+++ b/lib/format.js
@@ -71,7 +71,7 @@ Format.prototype.updateTables = function(colorTable, fontTable){
 
 //some RTF elements require that they are wrapped, closed by a trailing 0 and must have a spacebefore the text.
 function wrap(text, rtfwrapper){
-  return rtfwrapper + " " + text + rtfwrapper + "0";
+  return rtfwrapper + text + rtfwrapper + "0";
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 { 
   "name" : "@happy-doc/rtf",
-  "version" : "0.0.2",
+  "version" : "0.0.3",
   "description" : "Assists with creating rich text documents.",
   "main" : "./lib/rtf.js",
   "author" : "HappyDoc",


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add space for proper RTF rendering and newline in `formatText()` in `format.js`, update version in `package.json`.
> 
>   - **Behavior**:
>     - Add space in `formatText()` in `format.js` to ensure proper RTF rendering.
>     - Add newline character at the end of RTF document in `formatText()` in `format.js`.
>   - **Versioning**:
>     - Update version in `package.json` from `0.0.2` to `0.0.3`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=happy-doc%2Fnode-rtf&utm_source=github&utm_medium=referral)<sup> for 0c8367dbeab669e0ec0e830c6f88eb5054cd3fbd. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->