### PR TITLE
HDD-1725 RTF links

### DIFF
--- a/lib/elements/link.ts
+++ b/lib/elements/link.ts
@@ -1,0 +1,89 @@
+import { Format } from "../format";
+import { RGB } from "../rgb";
+import { Element } from "./element";
+import { getRTFSafeText } from "../rtf-utils";
+
+export class LinkElement extends Element {
+    url: string;
+    displayText: string;
+    isExternalURL: boolean; // Flag to indicate if the URL is external
+    constructor(url: string, displayText: string, format?: Format, isExternalURL: boolean = false) {
+        // If no format provided, create a default one for links
+        const linkFormat = format ?? new Format();
+
+        // Ensure typical link styling if not overridden
+        if (!linkFormat.color) {
+            linkFormat.color = RGB.BLUE; // Default to blue
+        }
+        if (!linkFormat.underline) {
+            linkFormat.underline = true; // Default to underline
+        }
+
+        super(linkFormat);
+        this.url = url;
+        this.displayText = displayText;
+        this.isExternalURL = isExternalURL; // Store the external URL flag
+    }
+
+    getRTFCode(
+        colorTable: Array<RGB>, // Use the RGB type
+        fontTable: string[],
+        callback: (err: Error | null, result?: string) => void
+    ): void {
+        try {
+            // Ensure format properties (color, font) are registered in tables
+            this.format.updateTables(colorTable, fontTable);
+
+            // Prepare format codes (font, size, color, underline, etc.)
+            let formatCodes = "";
+            if (this.format.fontPos >= 0) {
+                formatCodes += `\\f${this.format.fontPos}`;
+            }
+            if (this.format.fontSize > 0) {
+                formatCodes += `\\fs${this.format.fontSize * 2}`;
+            }
+             // Always add color for the link display text
+            if (this.format.colorPos >= 0) {
+                 // Add 1 because color table is 1-indexed in RTF (\cf1, \cf2, ...)
+                formatCodes += `\\cf${this.format.colorPos + 1}`;
+            }
+             // Always add underline for the link display text
+            if (this.format.underline) {
+                formatCodes += "\\ul";
+            }
+            if (this.format.bold) {
+                formatCodes += "\\b";
+            }
+            if (this.format.italic) {
+                formatCodes += "\\i";
+            }
+            // Add other format codes as needed (strike, super, sub)
+
+             // Escape the URL and display text for safety within RTF structure
+             // Note: URLs themselves might have issues if they contain complex chars,
+             // but basic escaping handles common cases like spaces or backslashes.
+            const safeUrl = getRTFSafeText(this.url);
+            const safeDisplayText = getRTFSafeText(this.displayText);
+
+            // Construct the RTF string for the hyperlink field
+            // Structure: {\pard \[format codes] {\field{\*\fldinst HYPERLINK "URL"}{\fldrslt [DISPLAY_TEXT]}}}[\format resets \pard]
+            // The outer {} and \pard ensures the formatting is scoped to the link.
+            // We apply format codes *before* the \field block.
+            // \fldrslt block inherits the preceding format.
+            let rtfString = `{\\pard ${formatCodes} ` // Start group, apply formatting
+                    
+            if (this.isExternalURL) {
+                // If it's an external URL, we need to add the external link format
+                rtfString += `{\\field{\\*\\fldinst HYPERLINK "${safeUrl}"}}{\\fldrslt ${safeDisplayText}}`; 
+            } else {
+                rtfString += `{\\field{\\*\\fldinst HYPERLINK A}{\\fldrslt ${safeUrl}}}`  // The field itself
+            }
+
+            rtfString += `\\ul0\\b0\\i0}`; // Reset specific styles and end group. \\pard might be needed depending on context.
+
+            callback(null, rtfString);
+        } catch (err) {
+            callback(err instanceof Error ? err : new Error(String(err)));
+        }
+    }
+}

--- a/lib/elements/link.ts
+++ b/lib/elements/link.ts
@@ -81,6 +81,9 @@ export class LinkElement extends Element {
 
             rtfString += `\\ul0\\b0\\i0}`; // Reset specific styles and end group. \\pard might be needed depending on context.
 
+            // Add the closing braces for the RTF structure (if needed)
+            //rtfString += `\\pard}`; // End the paragraph and reset formatting
+
             callback(null, rtfString);
         } catch (err) {
             callback(err instanceof Error ? err : new Error(String(err)));

--- a/lib/fonts.ts
+++ b/lib/fonts.ts
@@ -1,6 +1,7 @@
 export const Fonts = {
   ARIAL: "Arial",
-  COMIC_SANS: "Comic Sans MS",
+  CALIBRI: "Calibri",
+  COMIC_SANS: "Comic Sans MS",  
   GEORGIA: "Georgia",
   IMPACT: "Impact",
   TAHOMA: "Tahoma",
@@ -9,5 +10,4 @@ export const Fonts = {
   COURIER_NEW: "Courier New",
   PALATINO: "Palatino Linotype",
   TIMES_NEW_ROMAN: "Times New Roman",
-  CALIBARI: "Calibri",
 } as const;

--- a/lib/fonts.ts
+++ b/lib/fonts.ts
@@ -8,5 +8,6 @@ export const Fonts = {
   VERDANA: "Verdana",
   COURIER_NEW: "Courier New",
   PALATINO: "Palatino Linotype",
-  TIMES_NEW_ROMAN: "Times New Roman"
+  TIMES_NEW_ROMAN: "Times New Roman",
+  CALIBARI: "Calibri",
 } as const;

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -17,3 +17,5 @@ export * from './elements/group';
 export * from './elements/image';
 export * from './elements/table';
 export * from './elements/text';
+export * from './elements/link';
+export * from './elements/command';

--- a/lib/rgb.ts
+++ b/lib/rgb.ts
@@ -8,4 +8,7 @@ export class RGB {
     this.green = green;
     this.blue = blue;
   }
+
+  // Add a static constant for convenience
+  static readonly BLUE = new RGB(0, 0, 255);
 }

--- a/lib/rtf-utils.ts
+++ b/lib/rtf-utils.ts
@@ -10,6 +10,11 @@ export function getRTFSafeText(text: any): string {
   if (typeof text === "object" && text.hasOwnProperty("safe") && !text.safe) {
     return text.text;
   }
+
+  if (typeof text !== 'string') {
+    return '';
+  }
+
   return text.replaceAll('\\', '\\\\')
     .replaceAll('{', '\\{')
     .replaceAll('}', '\\}')

--- a/lib/rtf.ts
+++ b/lib/rtf.ts
@@ -1,4 +1,3 @@
-import { RGB } from "./rgb";
 import { Element } from "./elements/element"; // adjust the types as needed
 import { Format } from "./format";
 import * as Utils from "./rtf-utils";
@@ -8,6 +7,7 @@ import { TextElement } from "./elements/text";
 import { GroupElement } from "./elements/group";
 import async from "async";
 import { CommandElement } from "./elements/command";
+import { LinkElement } from "./elements/link";
 
 export class RTF {
   pageNumbering: boolean;
@@ -44,6 +44,16 @@ export class RTF {
 
   writeText(text: string, format?: Format, groupName?: string) {
     const element = new TextElement(text, format);
+    const groupIndex = this._groupIndex(groupName);
+    if (groupName !== undefined && groupIndex >= 0) {
+      (this.elements[groupIndex] as GroupElement).addElement(element);
+    } else {
+      this.elements.push(element);
+    }
+  }
+
+  writeLink(url: string, displayText: string, format?: Format, groupName?: string) {
+    const element = new LinkElement(url, displayText, format);
     const groupIndex = this._groupIndex(groupName);
     if (groupName !== undefined && groupIndex >= 0) {
       (this.elements[groupIndex] as GroupElement).addElement(element);

--- a/lib/rtf.ts
+++ b/lib/rtf.ts
@@ -52,8 +52,8 @@ export class RTF {
     }
   }
 
-  writeLink(url: string, displayText: string, format?: Format, groupName?: string) {
-    const element = new LinkElement(url, displayText, format);
+  writeLink(url: string, displayText: string, format?: Format, groupName?: string, isExternalURL?: boolean) {
+    const element = new LinkElement(url, displayText, format, isExternalURL);
     const groupIndex = this._groupIndex(groupName);
     if (groupName !== undefined && groupIndex >= 0) {
       (this.elements[groupIndex] as GroupElement).addElement(element);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@happy-doc/rtf",
-    "version": "0.1.2",
+    "version": "0.1.3-beta-1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@happy-doc/rtf",
-            "version": "0.1.2",
+            "version": "0.1.3-beta-1",
             "license": "MIT",
             "dependencies": {
                 "async": "^0.9.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@happy-doc/rtf",
-    "version": "0.1.3-beta-1",
+    "version": "0.1.3",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@happy-doc/rtf",
-            "version": "0.1.3-beta-1",
+            "version": "0.1.3",
             "license": "MIT",
             "dependencies": {
                 "async": "^0.9.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@happy-doc/rtf",
-    "version": "0.1.2",
+    "version": "0.1.3",
     "description": "Assists with creating rich text documents.",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds `LinkElement` for RTF links, updates `RTF` class for link support, and includes minor utility and font updates.
> 
>   - **New Feature**:
>     - Adds `LinkElement` class in `link.ts` to handle RTF links with URL, display text, and external URL flag.
>     - Implements `getRTFCode()` in `LinkElement` to generate RTF string for hyperlinks.
>   - **RTF Class**:
>     - Adds `writeLink()` method in `RTF` class to add links to documents.
>   - **Utilities**:
>     - Adds `BLUE` constant to `RGB` class in `rgb.ts`.
>     - Updates `getRTFSafeText()` in `rtf-utils.ts` to handle non-string inputs.
>   - **Fonts**:
>     - Adds `CALIBRI` to `Fonts` in `fonts.ts`.
>   - **Misc**:
>     - Exports `LinkElement` in `index.ts`.
>     - Bumps version to `0.1.3` in `package.json`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=happy-doc%2Fnode-rtf&utm_source=github&utm_medium=referral)<sup> for 6c5c74c57198e34f1ab60f393304a2b7233943ce. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->